### PR TITLE
fix: README SwiftUI example is more SwiftUI-like

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,22 @@ vs. SwiftUI...
 
 ```swift
 struct App: View {
-  @State var text = "";
-  var body: some View {
-    VStack(alignment: .leading) {
-      Text("Some cool text").font(.title)
-      TextField("Name", text: $text)
-      Button(action: doSomething) {
-        Text("Click the cool button")
-      }
-    }.background(Color(UIColor.systemGray6))
-    .padding(.leading, 30)
-    .cornerRadius(20)
-  }
+    
+    @State var text = ""
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Some cool text")
+                .font(.title)
+            TextField("Name", text: $text)
+            Button(action: doSomething) {
+                Text("Click the cool button")
+            }
+        }
+        .background(Color(.systemGray6))
+        .padding(.leading, 30)
+        .cornerRadius(20)
+    }
 }
 ```
 


### PR DESCRIPTION
@andrew-levy Caught my eye after the 6th or 7th look that tabbing etc. of the SwiftUI example could look a bit more  SwiftUI-like. Open to your feedback.