### PR TITLE
Added built in button styles

### DIFF
--- a/docs/docs/03-API/02-Views/04-Button.md
+++ b/docs/docs/03-API/02-Views/04-Button.md
@@ -14,8 +14,8 @@ import TabItem from '@theme/TabItem';
 ### Verbose
 
 ```tsx
-<Button action={doSomething}>
-  <Text fontWeight="bold" fontSize={24}>
+<Button action={doSomething} buttonStyle="borderedProminent">
+  <Text bold fontSize={24}>
     Click the cool button
   </Text>
 </Button>
@@ -24,7 +24,12 @@ import TabItem from '@theme/TabItem';
 ### Shorthand
 
 ```tsx
-<Button title="Click the cool button" fontWeight="bold" action={doSomething} />
+<Button
+  title="Click the cool button"
+  action={doSomething}
+  buttonStyle="borderedProminent"
+  bold
+/>
 ```
 
 </TabItem>
@@ -36,7 +41,7 @@ import TabItem from '@theme/TabItem';
 Button(action: doSomething) {
     Text("Click the cool button")
         .fontWeight(.bold)
-}
+}.buttonStyle(.borderedProminent)
 ```
 
 ### Shorthand
@@ -44,6 +49,7 @@ Button(action: doSomething) {
 ```swift
 Button("Click the cool button", action: doSomething)
   .fontWeight(.bold)
+  .buttonStyle(.borderedProminent)
 ```
 
 </TabItem>
@@ -62,9 +68,14 @@ Button("Click the cool button", action: doSomething)
 
 Button inherits all [View Modifiers](../modifiers#view-modifiers) and [Text Modifiers](../modifiers#text-modifiers) as props.
 
-| prop       | description                                          | type         | required | default     |
-| ---------- | ---------------------------------------------------- | ------------ | -------- | ----------- |
-| `title`    | The text of the button.                              | `string`     | yes      | `undefined` |
-| `action`   | The action to perform when the user taps the button. | `() => void` | yes      | `undefined` |
-| `disabled` | Whether the button is able to be clicked.            | `boolean`    | no       | `undefined` |
-| `children` | The button content.                                  | `ReactNode`  | no       | `undefined` |
+| prop          | description                                          | type          | required | default        |
+| ------------- | ---------------------------------------------------- | ------------- | -------- | -------------- |
+| `title`       | The text of the button.                              | `string`      | yes      | `undefined`    |
+| `action`      | The action to perform when the user taps the button. | `() => void`  | yes      | `undefined`    |
+| `disabled`    | Whether the button is able to be clicked.            | `boolean`     | no       | `undefined`    |
+| `buttonStyle` | The button style                                     | `ButtonStyle` | no       | `'borderless'` |
+| `children`    | The button content.                                  | `ReactNode`   | no       | `undefined`    |
+
+```ts
+type ButtonStyle = 'bordered' | 'borderedProminent' | 'plain' | 'borderless';
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftui-react-native",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "A React Native component library inspired by SwiftUI",
   "main": "main.js",
   "typings": "main.d.ts",

--- a/src/hooks/useColorScheme.ts
+++ b/src/hooks/useColorScheme.ts
@@ -3,7 +3,7 @@ import { Modifiers } from '../utils/modifiers';
 import { EnvironmentProviderContext } from '../views/EnvironmentProvider/EnvironmentProvider';
 
 export const useColorScheme = (
-  preferredColorScheme: Modifiers['preferredColorScheme']
+  preferredColorScheme?: Modifiers['preferredColorScheme']
 ) => {
   const colorScheme =
     useContext(EnvironmentProviderContext)?.colorScheme || 'light';

--- a/src/views/Button/Button.tsx
+++ b/src/views/Button/Button.tsx
@@ -10,7 +10,7 @@ import { useLifecycle } from '../../hooks/useLifecycle';
 import { getCornerRadius } from '../../utils/cornerRadius';
 import { getTransform } from '../../utils/transform';
 import { useColorScheme } from '../../hooks/useColorScheme';
-import { getColor } from '../../utils/colors';
+import { getColor, UIColor } from '../../utils/colors';
 import { useAlert } from '../../hooks/useAlert';
 
 export type ButtonProps = Modifiers &
@@ -19,6 +19,7 @@ export type ButtonProps = Modifiers &
     action?: () => void;
     disabled?: boolean;
     title?: string;
+    buttonStyle?: 'bordered' | 'borderless' | 'borderedProminent' | 'plain';
   }>;
 
 export const Button = ({
@@ -36,6 +37,7 @@ export const Button = ({
   shadow,
   opacity,
   zIndex,
+  buttonStyle = 'borderless',
   children,
   style,
   preferredColorScheme,
@@ -47,6 +49,52 @@ export const Button = ({
   useLifecycle(onAppear, onDisappear);
   const colorScheme = useColorScheme(preferredColorScheme);
 
+  function getButtonTextColor(): UIColor {
+    switch (buttonStyle) {
+      case 'borderless':
+      case 'bordered':
+        return 'systemBlue';
+      case 'plain':
+        return 'label';
+      case 'borderedProminent':
+        return 'white';
+    }
+  }
+
+  function getButtonBackgroundColor(): UIColor {
+    switch (buttonStyle) {
+      case 'borderless':
+      case 'plain':
+        return;
+      case 'bordered':
+        return 'systemGray5';
+      case 'borderedProminent':
+        return 'systemBlue';
+    }
+  }
+
+  function getButtonPadding() {
+    switch (buttonStyle) {
+      case 'borderless':
+      case 'plain':
+        return;
+      case 'bordered':
+      case 'borderedProminent':
+        return { horizontal: 12, vertical: 8 };
+    }
+  }
+
+  function getButtonCornerRadius() {
+    switch (buttonStyle) {
+      case 'borderless':
+      case 'plain':
+        return;
+      case 'bordered':
+      case 'borderedProminent':
+        return 8;
+    }
+  }
+
   return (
     <TouchableOpacity
       disabled={disabled}
@@ -56,9 +104,12 @@ export const Button = ({
           justifyContent: 'center',
           opacity,
           zIndex,
-          backgroundColor: getColor(backgroundColor, colorScheme),
-          ...getCornerRadius(cornerRadius),
-          ...getPadding(padding),
+          backgroundColor: getColor(
+            backgroundColor || getButtonBackgroundColor(),
+            colorScheme
+          ),
+          ...getCornerRadius(cornerRadius || getButtonCornerRadius()),
+          ...getPadding(padding || getButtonPadding()),
           ...getFrame(frame),
           ...getBorder(border, colorScheme),
           ...getShadow(shadow, colorScheme),
@@ -68,14 +119,20 @@ export const Button = ({
       ]}
     >
       {title ? (
-        <Text foregroundColor="systemBlue" {...textProps}>
+        <Text
+          foregroundColor={getColor(getButtonTextColor(), colorScheme)}
+          {...textProps}
+        >
           {title}
         </Text>
       ) : (
         React.Children.map(children as ReactElement<any>[], (child) =>
           child
             ? React.cloneElement(child, {
-                ...{ foregroundColor: 'systemBlue', ...textProps },
+                ...{
+                  foregroundColor: getColor(getButtonTextColor(), colorScheme),
+                  ...textProps,
+                },
                 ...child.props,
               })
             : null

--- a/src/views/Text/Text.tsx
+++ b/src/views/Text/Text.tsx
@@ -6,7 +6,7 @@ import { getFrame } from '../../utils/frame';
 import { getBorder } from '../../utils/border';
 import { useLifecycle } from '../../hooks/useLifecycle';
 import { getFont } from '../../utils/fonts';
-import { Modifiers, TextModifiers } from '../../utils/modifiers';
+import { Modifiers, TextModifiers, WithChildren } from '../../utils/modifiers';
 import { TextAlignment } from '../../utils/alignments';
 import { getCornerRadius } from '../../utils/cornerRadius';
 import { getTransform } from '../../utils/transform';
@@ -16,11 +16,12 @@ import { useAlert } from '../../hooks/useAlert';
 import { getTextDecoration } from '../../utils/textDecoration';
 
 type TextProps = Omit<Modifiers, 'style'> &
-  TextModifiers & {
+  TextModifiers &
+  WithChildren<{
     textCase?: 'lower' | 'upper' | 'capitalize';
     alignment?: TextAlignment;
     style?: StyleProp<TextStyle>;
-  };
+  }>;
 
 export const Text: React.FC<TextProps> = ({
   font = 'body',


### PR DESCRIPTION
Added a new modifier for Buttons: `buttonStyle`. Matches https://sarunw.com/posts/swiftui-button-style-examples/

To Do:

- [x] Add new modifier
- [x] Initial smoke testing
- [x] Update docs
- [x] More testing


<img width="329" alt="Screenshot 2023-01-22 at 6 02 21 PM" src="https://user-images.githubusercontent.com/29075740/213945063-b759cd06-3da3-43bf-bbaf-7f44efc69f2d.png">
