### PR TITLE
Feature/linear gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,3 @@ Check out the [official documentation](https://swiftui-react-native.vercel.app).
 ## Example Project
 
 Check out the [example project](./example/).
-
-Changelog:
-
-- Added button role prop
-- Added fixedSize and lineLimit modifier props
-- picker height issue

--- a/docs/docs/03-API/08-modifiers.md
+++ b/docs/docs/03-API/08-modifiers.md
@@ -19,14 +19,14 @@ To approximate this in React Native, views are styled using props. Each prop cor
 | --------------------------- | ------------------------------------------------------------------------------------------------ |
 | padding                     | number \| boolean \| { leading?: number; top?: number; bottom?: number; trailing?: number; ... } |
 | border                      | { color?: Color; width?: number; }                                                               |
-| foregroundStyle             | Color \| Color[]                                                                                 |
+| foregroundStyle             | Color \| Color[] \| LinearGradient                                                               |
 | rotationEffect              | { degrees?: number; radians?: number; }                                                          |
 | ignoresSafeArea             | boolean                                                                                          |
 | lineLimit                   | number                                                                                           |
 | fixedSize                   | boolean \| { horizontal: boolean; vertical: boolean };                                           |
 | scaleEffect                 | number                                                                                           |
 | shadow                      | { color?: Color; x?: number; y?: number; radius: number; opacity?: number; }                     |
-| background                  | Color                                                                                            |
+| background                  | Color \| LinearGradient                                                                          |
 | hidden                      | boolean                                                                                          |
 | frame                       | Frame                                                                                            |
 | zIndex                      | number                                                                                           |

--- a/docs/docs/03-API/08-modifiers.md
+++ b/docs/docs/03-API/08-modifiers.md
@@ -38,6 +38,7 @@ To approximate this in React Native, views are styled using props. Each prop cor
 | animation                   | { type: 'spring' \| 'easeIn' \| 'easeOut' \| 'easeInOut' \| 'linear' \| ...; value: any; }       |
 | contentTransition           | 'numericText' \| 'opacity' \| 'identity' \| 'interpolate' \| 'symbolEffect'                      |
 | labelIsHidden               | boolean                                                                                          |
+| redacted                    | 'placeholder' \| 'invalidated' \| 'privacy'                                                      |
 | blur                        | number                                                                                           |
 | saturation                  | number                                                                                           |
 | grayscale                   | number                                                                                           |

--- a/docs/docs/03-API/08-modifiers.md
+++ b/docs/docs/03-API/08-modifiers.md
@@ -44,6 +44,7 @@ To approximate this in React Native, views are styled using props. Each prop cor
 | brightness                  | number                                                                                           |
 | contrast                    | number                                                                                           |
 | blendMode                   | 'color' \| 'colorBurn' \| 'colorDodge' \| 'darken' \| 'difference' \| ...                        |
+| compositingGroup            | boolean                                                                                          |
 | mask                        | string                                                                                           |
 | clipShape                   | 'circle' \| 'roundedRectangle' \| 'capsule' \| 'rectangle' \| 'ellipse' \| ...                   |
 | environment                 | { colorScheme: 'light' \| 'dark'; }                                                              |

--- a/example/src/sections/FilterSection.tsx
+++ b/example/src/sections/FilterSection.tsx
@@ -6,6 +6,7 @@ import {
   Rectangle,
   Spacer,
   Text,
+  ZStack,
 } from 'swiftui-react-native';
 
 export const FilterSection = () => {
@@ -60,6 +61,34 @@ export const FilterSection = () => {
         <Image systemName="arrow.right" />
         <Rectangle fill="accentColor" blendMode="difference" />
       </HStack>
+      <ZStack
+        frame={{ height: 500 }}
+        compositingGroup
+        shadow={{
+          color: 'gray',
+          radius: 15,
+          x: -10,
+          y: 10,
+        }}
+      >
+        <Image
+          systemName={'lanyardcard.fill' as any}
+          fontSize={400}
+          foregroundStyle={{
+            linearGradient: {
+              colors: ['gray', 'white'],
+              startPoint: 'bottomLeading',
+              endPoint: 'topTrailing',
+            },
+          }}
+        />
+        <Image
+          systemName="applelogo"
+          fontSize={170}
+          padding={{ top: 100 }}
+          blendMode="destinationOut"
+        />
+      </ZStack>
     </List>
   );
 };

--- a/ios/Common/View+Modifiers.swift
+++ b/ios/Common/View+Modifiers.swift
@@ -518,6 +518,24 @@ struct ReactNativeViewModifiers: ViewModifier {
           if let cornerRadius = value as? CGFloat {
             view = AnyView(view.cornerRadius(cornerRadius))
           }
+
+        case "redacted": 
+         if let reason = value as? String {
+           if #available(iOS 15.0, *) {
+             switch reason {
+             case "placeholder":
+               view = AnyView(view.redacted(reason: .placeholder))
+             case "privacy":
+              view = AnyView(view.redacted(reason: .privacy))
+            case "invalidated":
+               if #available(iOS 17.0, *) {
+                 view = AnyView(view.redacted(reason: .invalidated))
+               }
+             default:
+               break
+             }
+           }
+         }
           
         case "buttonStyle":
           if let buttonStyle = value as? String {

--- a/ios/Common/View+Modifiers.swift
+++ b/ios/Common/View+Modifiers.swift
@@ -48,7 +48,7 @@ struct ReactNativeViewModifiers: ViewModifier {
             )
             
             view = AnyView(view.padding(edgeInsets))
-          
+            
           }
         case "border":
           if let border = value as? [String: Any] {
@@ -65,15 +65,14 @@ struct ReactNativeViewModifiers: ViewModifier {
           }
           
         case "foregroundStyle":
-          if let color = getColor(value) as Color? {
+          if let colorVal = value as? String {
+            let color = getColor(colorVal) as Color?
             if #available(iOS 15.0, *) {
-              view = AnyView(view.foregroundStyle(color))
-            } else {
-              
+              view = AnyView(view.foregroundStyle(color ?? .black))
             }
-          } else if let color = value as? [Any] {
-            let colors = getColors(color) as [Color]
-            switch color.count {
+          } else if let colorArr = value as? [String] {
+            let colors = getColors(colorArr) as [Color]
+            switch colors.count {
             case 1:
               if #available(iOS 15.0, *) {
                 view = AnyView(view.foregroundStyle(colors[0]))
@@ -89,12 +88,41 @@ struct ReactNativeViewModifiers: ViewModifier {
             default:
               break
             }
+          } else if let colorObj = value as? [String: Any] {
+            if let linearGradient = colorObj["linearGradient"] as? [String: Any] {
+              let startPointString = linearGradient["startPoint"] as? String ?? "topLeading"
+              let endPointString = linearGradient["endPoint"] as? String ?? "bottomTrailing"
+              let startPoint = mapToUnitPoint(startPointString)
+              let endPoint = mapToUnitPoint(endPointString)
+              let gradient = LinearGradient(
+                gradient: Gradient(colors: getColors(linearGradient["colors"] ?? [])),
+                startPoint: startPoint,
+                endPoint: endPoint
+              )
+              if #available(iOS 15.0, *) {
+                view = AnyView(view.foregroundStyle(gradient))
+              }
+            }
           }
-          // Currently only supports color
+          
         case "background":
-          if let color = getColor(value) as Color? {
-            view = AnyView(view.background(color))
+          if let color = value as? String {
+            view = AnyView(view.background(getColor(color)))
+          } else if let color = value as? [String: Any] {
+            if let linearGradient = color["linearGradient"] as? [String: Any] {
+              let startPointString = linearGradient["startPoint"] as? String ?? "topLeading"
+              let endPointString = linearGradient["endPoint"] as? String ?? "bottomTrailing"
+              let startPoint = mapToUnitPoint(startPointString)
+              let endPoint = mapToUnitPoint(endPointString)
+              let gradient = LinearGradient(
+                gradient: Gradient(colors: getColors(linearGradient["colors"] ?? [])),
+                startPoint: startPoint,
+                endPoint: endPoint
+              )
+              view = AnyView(view.background(gradient))
+            } 
           }
+
         case "rotationEffect":
           if let rotation = value as? [String: CGFloat] {
             if let degrees = rotation["degrees"] {
@@ -194,7 +222,9 @@ struct ReactNativeViewModifiers: ViewModifier {
               break
             }
           }
-        case "ignoresSafeArea": 
+        case "compositingGroup":
+          view = AnyView(view.compositingGroup())
+        case "ignoresSafeArea":
           if let ignoresSafeArea = value as? Bool {
             if ignoresSafeArea == true {
               if #available(iOS 14.0, *) {
@@ -935,12 +965,38 @@ func getColor(_ color: Any?) -> Color {
 }
 
 
-func getColors(_ colors: [Any]?) -> [Color] {
+func getColors(_ colors: Any) -> [Color] {
   var result: [Color] = []
-  if let colors = colors {
+  if let colors = colors as? [Any] {
     for color in colors {
       result.append(getColor(color))
     }
   }
   return result
+}
+
+
+func mapToUnitPoint(_ point: String) -> UnitPoint {
+  switch point {
+  case "topLeading":
+    return .topLeading
+  case "top":
+    return .top
+  case "topTrailing":
+    return .topTrailing
+  case "leading":
+    return .leading
+  case "center":
+    return .center
+  case "trailing":
+    return .trailing
+  case "bottomLeading":
+    return .bottomLeading
+  case "bottom":
+    return .bottom
+  case "bottomTrailing":
+    return .bottomTrailing
+  default:
+    return .center
+  }
 }

--- a/ios/Common/View+Modifiers.swift
+++ b/ios/Common/View+Modifiers.swift
@@ -90,15 +90,7 @@ struct ReactNativeViewModifiers: ViewModifier {
             }
           } else if let colorObj = value as? [String: Any] {
             if let linearGradient = colorObj["linearGradient"] as? [String: Any] {
-              let startPointString = linearGradient["startPoint"] as? String ?? "topLeading"
-              let endPointString = linearGradient["endPoint"] as? String ?? "bottomTrailing"
-              let startPoint = mapToUnitPoint(startPointString)
-              let endPoint = mapToUnitPoint(endPointString)
-              let gradient = LinearGradient(
-                gradient: Gradient(colors: getColors(linearGradient["colors"] ?? [])),
-                startPoint: startPoint,
-                endPoint: endPoint
-              )
+             let gradient = getLinearGradient(linearGradient)
               if #available(iOS 15.0, *) {
                 view = AnyView(view.foregroundStyle(gradient))
               }
@@ -110,15 +102,7 @@ struct ReactNativeViewModifiers: ViewModifier {
             view = AnyView(view.background(getColor(color)))
           } else if let color = value as? [String: Any] {
             if let linearGradient = color["linearGradient"] as? [String: Any] {
-              let startPointString = linearGradient["startPoint"] as? String ?? "topLeading"
-              let endPointString = linearGradient["endPoint"] as? String ?? "bottomTrailing"
-              let startPoint = mapToUnitPoint(startPointString)
-              let endPoint = mapToUnitPoint(endPointString)
-              let gradient = LinearGradient(
-                gradient: Gradient(colors: getColors(linearGradient["colors"] ?? [])),
-                startPoint: startPoint,
-                endPoint: endPoint
-              )
+              let gradient = getLinearGradient(linearGradient)
               view = AnyView(view.background(gradient))
             } 
           }
@@ -223,7 +207,11 @@ struct ReactNativeViewModifiers: ViewModifier {
             }
           }
         case "compositingGroup":
-          view = AnyView(view.compositingGroup())
+          if let compositingGroup = value as? Bool {
+            if compositingGroup == true {
+              view = AnyView(view.compositingGroup())
+            }
+          }
         case "ignoresSafeArea":
           if let ignoresSafeArea = value as? Bool {
             if ignoresSafeArea == true {
@@ -999,4 +987,16 @@ func mapToUnitPoint(_ point: String) -> UnitPoint {
   default:
     return .center
   }
+}
+
+func getLinearGradient(_ obj: [String: Any]) -> LinearGradient {
+  let startPointString = obj["startPoint"] as? String ?? "topLeading"
+  let endPointString = obj["endPoint"] as? String ?? "bottomTrailing"
+  let startPoint = mapToUnitPoint(startPointString)
+  let endPoint = mapToUnitPoint(endPointString)
+  return LinearGradient(
+    gradient: Gradient(colors: getColors(obj["colors"] ?? [])),
+    startPoint: startPoint,
+    endPoint: endPoint
+  )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftui-react-native",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "A React Native component library inspired by SwiftUI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/experimental/createSwiftUIComponent.ts
+++ b/src/experimental/createSwiftUIComponent.ts
@@ -75,6 +75,10 @@ export type ElementWithModifiers = JSX.Element & {
   labelIsHidden: () => ElementWithModifiers;
   fill: (color: Modifiers['fill']) => ElementWithModifiers;
   stroke: (stroke: Modifiers['stroke']) => ElementWithModifiers;
+  redacted: (reason: Modifiers['redacted']) => ElementWithModifiers;
+  ignoresSafeArea: (
+    ignoresSafeArea: Modifiers['ignoresSafeArea']
+  ) => ElementWithModifiers;
   style: (style: StyleProp<ViewStyle | TextStyle>) => ElementWithModifiers;
 };
 
@@ -333,6 +337,16 @@ export function createSwiftUIComponent(
 
   Element.stroke = function (stroke) {
     this.props._modifiers = [...this.props._modifiers, { stroke }];
+    return this;
+  };
+
+  Element.redacted = function (reason) {
+    this.props._modifiers = [...this.props._modifiers, { redacted: reason }];
+    return this;
+  };
+
+  Element.ignoresSafeArea = function (ignoresSafeArea) {
+    this.props._modifiers = [...this.props._modifiers, { ignoresSafeArea }];
     return this;
   };
 

--- a/src/utils/modifiers/index.ts
+++ b/src/utils/modifiers/index.ts
@@ -72,6 +72,7 @@ export type Modifiers = {
     degrees?: number;
     radians?: number;
   };
+  redacted?: 'privacy' | 'placeholder' | 'invalidated';
   scaleEffect?: number;
   shadow?: {
     color?: Color;

--- a/src/utils/modifiers/index.ts
+++ b/src/utils/modifiers/index.ts
@@ -24,6 +24,30 @@ type Color =
   | `rgb${string}`
   | (string & {});
 
+type LinearGradient = {
+  linearGradient: {
+    colors: Color[];
+    startPoint:
+      | 'top'
+      | 'bottom'
+      | 'leading'
+      | 'trailing'
+      | 'topLeading'
+      | 'topTrailing'
+      | 'bottomLeading'
+      | 'bottomTrailing';
+    endPoint:
+      | 'top'
+      | 'bottom'
+      | 'leading'
+      | 'trailing'
+      | 'topLeading'
+      | 'topTrailing'
+      | 'bottomLeading'
+      | 'bottomTrailing';
+  };
+};
+
 export type Modifiers = {
   // View
   ignoresSafeArea?: boolean;
@@ -43,7 +67,7 @@ export type Modifiers = {
     color?: Color;
     width?: number;
   };
-  foregroundStyle?: Color | Color[];
+  foregroundStyle?: Color | Color[] | LinearGradient;
   rotationEffect?: {
     degrees?: number;
     radians?: number;
@@ -53,10 +77,10 @@ export type Modifiers = {
     color?: Color;
     x?: number;
     y?: number;
-    radius: number;
+    radius?: number;
     opacity?: number;
   };
-  background?: Color;
+  background?: Color | LinearGradient;
   hidden?: boolean;
   frame?:
     | {
@@ -75,7 +99,7 @@ export type Modifiers = {
   cornerRadius?: number;
   position?: { x: number; y: number };
   offset?: { x: number; y: number };
-  fixedSize?: boolean | { horizontal: boolean; vertical: boolean };
+  fixedSize?: boolean | { horizontal?: boolean; vertical?: boolean };
   lineLimit?: number;
   animation?: {
     type:
@@ -103,6 +127,7 @@ export type Modifiers = {
   grayscale?: number;
   brightness?: number;
   contrast?: number;
+  compositingGroup?: boolean;
   blendMode?:
     | 'color'
     | 'colorBurn'
@@ -282,7 +307,7 @@ export type Modifiers = {
   };
   // List
   scrollDisabled?: boolean;
-  // Lifecycle - todo
+  // Lifecycle
   onAppear?: () => void;
   onDisappear?: () => void;
   // contextMenu?: ContextMenu;


### PR DESCRIPTION
- Added `compositingGroup` prop 
- Added `linearGradient` property to `foregroundStyle` and `background` props

## Example usage:

```tsx
<ZStack
  frame={{ height: 500 }}
  compositingGroup
  shadow={{
    color: 'gray',
    radius: 15,
    x: -10,
    y: 10,
  }}
>
  <Image
    systemName={'lanyardcard.fill' as any}
    fontSize={400}
    foregroundStyle={{
      linearGradient: {
        colors: ['gray', 'white'],
        startPoint: 'bottomLeading',
        endPoint: 'topTrailing',
      },
    }}
  />
  <Image
    systemName="applelogo"
    fontSize={170}
    padding={{ top: 100 }}
    blendMode="destinationOut"
  />
</ZStack>
```

<img width="848" alt="Screenshot 2024-05-23 at 9 22 04 PM" src="https://github.com/andrew-levy/swiftui-react-native/assets/29075740/45caa10f-bc17-430b-94d9-42e415c6f84a">
