### PR TITLE
Fix expo image conflict

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "expo": "^51.0.14",
     "expo-constants": "~16.0.2",
+    "expo-image": "~1.13.0",
     "expo-linking": "~6.3.1",
     "expo-router": "~3.5.16",
     "expo-splash-screen": "~0.27.5",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -3195,6 +3195,11 @@ expo-font@~12.0.7:
   dependencies:
     fontfaceobserver "^2.1.0"
 
+expo-image@~1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-1.13.0.tgz#f0ad585ecf57f6df2d8524f5e9275cb12b349836"
+  integrity sha512-0NLDcFmEn4Nh1sXeRvNzDHT+Fl6FXtTol6ki6kYYH0/iDeSFWyIy/Fek6kzDDYAmhipSMR7buPf7VVoHseTbAA==
+
 expo-keep-awake@~13.0.2:
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/expo-keep-awake/-/expo-keep-awake-13.0.2.tgz#5ef31311a339671eec9921b934fdd90ab9652b0e"

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -4,7 +4,7 @@
     "modules": [
       "ColorPickerModule",
       "StepperModule",
-      "ImageModule",
+      "SwiftUIImageModule",
       "ShapeModule",
       "ProgressModule",
       "PickerModule",

--- a/ios/Image/SwiftUIImageModule.swift
+++ b/ios/Image/SwiftUIImageModule.swift
@@ -1,8 +1,8 @@
 import ExpoModulesCore
 
-public class ImageModule: Module {
+public class SwiftUIImageModule: Module {
   public func definition() -> ModuleDefinition {
-    Name("Image")
+    Name("SwiftUIImage")
     View(ImageExpoView.self) {
       Events("onEvent")
       Prop("systemName") { (view: ImageExpoView, prop: String) in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftui-react-native",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "A React Native component library inspired by SwiftUI",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/views/Image/Image.ios.tsx
+++ b/src/views/Image/Image.ios.tsx
@@ -8,7 +8,7 @@ import { onBaseEvent } from '../../utils/onBaseEvent';
 import { ImageProps, NativeImageProps } from './types';
 
 const NativeImage: React.ComponentType<NativeImageProps> =
-  requireNativeViewManager('Image');
+  requireNativeViewManager('SwiftUIImage');
 
 export function Image({ style, systemName, ...modifiers }: ImageProps) {
   return (


### PR DESCRIPTION
Fixes #50 

Expo Image's module had the same name as this library's image component `ImageModule`